### PR TITLE
provider ref + modify macro a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,14 @@ Any type implementing the `CairoType` trait can be used this way.
 ## Generate the binding for your contracts
 
 1. If you have a large ABI, consider adding a file (at the same level of your `Cargo.toml`) with the `JSON` containing the ABI.
-Then you can load the whole file using:
+   Then you can load the whole file using:
+
 ```rust
 abigen!(MyContract, "./mycontract.abi.json")
 ```
 
 2. If you only want to make a quick call without too much setup, you can paste an ABI directly using:
+
 ```rust
 abigen!(MyContract, r#"
 [
@@ -104,7 +106,7 @@ use abigen_macro::abigen;
 use anyhow::Result;
 use cairo_types::ty::CairoType;
 
-use starknet::accounts::Account;
+use starknet::accounts::{Account, SingleOwnerAccount};
 
 use starknet::core::types::*;
 use starknet::providers::{jsonrpc::HttpTransport, AnyProvider, JsonRpcClient, Provider};
@@ -123,26 +125,26 @@ async fn main() -> Result<()> {
         "0x0546a164c8d10fd38652b6426ef7be159965deb9a0cbf3e8a899f8a42fd86761",
     ).unwrap();
 
-    // Call.
-    let contract_caller = MyContract::new_caller(contract_address, provider).await?;
-    let val = contract_caller.get_val().await?;
-
-    // Work in progress to avoid this duplication.
-    let provider2 =
-        AnyProvider::JsonRpcHttp(JsonRpcClient::new(HttpTransport::new(rpc_url.clone())));
+     // Work in progress for implicit type.
+    let my_contract: <&AnyProvider, SingleOwnerAccount<AnyProvider, LocalWallet>> = MyContract::new(contract_address, &provider);
+    let val = my_contract.get_val().await?;
 
     let account_address = FieldElement::from_hex_be(
         "0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
     ).unwrap();
 
+    // It's generic. Allow user to prvide own signer and account.
     let signer = wallet_from_private_key(&Some(
         "0x0000001800000000300000180000000000030000000000003006001800006600".to_string(),
     )).unwrap();
+    let account = SingleOwnerAccount::new(&provider, signer, account_address, chain_id);
 
-    // Invoke.
-    let contract_invoker =
-        MyContract::new_invoker(contract_address, provider2, account_address, signer).await?;
-    contract_invoker.set_val(FieldElement::TWO).await?;
+    // Invoke. You can define either this way,
+    let my_contract_invoke = MyContract::new(contract_address, &provider).with_account(&account).await?;
+    // Or this way.
+    //  let my_contract_invoke = my_contract.with_account(&account).await?;
+
+    my_contract_invoke.set_val(FieldElement::TWO).await?;
 }
 
 // Util function to create a LocalWallet.

--- a/README.md
+++ b/README.md
@@ -121,30 +121,23 @@ async fn main() -> Result<()> {
     let provider =
         AnyProvider::JsonRpcHttp(JsonRpcClient::new(HttpTransport::new(rpc_url.clone())));
 
-    let contract_address = FieldElement::from_hex_be(
-        "0x0546a164c8d10fd38652b6426ef7be159965deb9a0cbf3e8a899f8a42fd86761",
-    ).unwrap();
+    let contract_address = felt!("0x0546a164c8d10fd38652b6426ef7be159965deb9a0cbf3e8a899f8a42fd86761");
 
-     // Work in progress for implicit type.
-    let my_contract: <&AnyProvider, SingleOwnerAccount<AnyProvider, LocalWallet>> = MyContract::new(contract_address, &provider);
+     // Call.
+    let my_contract = MyContract::new(contract_address, &provider);
     let val = my_contract.get_val().await?;
 
-    let account_address = FieldElement::from_hex_be(
-        "0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
-    ).unwrap();
+     let account_address = felt!("0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973");
 
-    // It's generic. Allow user to prvide own signer and account.
     let signer = wallet_from_private_key(&Some(
         "0x0000001800000000300000180000000000030000000000003006001800006600".to_string(),
     )).unwrap();
     let account = SingleOwnerAccount::new(&provider, signer, account_address, chain_id);
 
-    // Invoke. You can define either this way,
-    let my_contract_invoke = MyContract::new(contract_address, &provider).with_account(&account).await?;
-    // Or this way.
-    //  let my_contract_invoke = my_contract.with_account(&account).await?;
+    // Invoke.
+    let mycontract = MyContract::new(contract_address, &provider).with_account(&account).await?;
 
-    my_contract_invoke.set_val(FieldElement::TWO).await?;
+    mycontract.set_val(FieldElement::TWO).await?;
 }
 
 // Util function to create a LocalWallet.

--- a/crates/abigen-macro/src/expand/enum.rs
+++ b/crates/abigen-macro/src/expand/enum.rs
@@ -39,7 +39,7 @@ impl Expandable for CairoEnum {
 
         for (i, val) in self.variants.iter().enumerate() {
             let variant_name = str_to_ident(&val.0);
-            let ty = str_to_type(&val.1.to_rust_item_path());
+            let ty = str_to_type(&val.1.to_rust_type_path());
 
             // Tuples type used as rust type path must be surrounded
             // by LT/GT.

--- a/crates/abigen-macro/src/expand/function.rs
+++ b/crates/abigen-macro/src/expand/function.rs
@@ -104,18 +104,11 @@ impl Expandable for CairoFunction {
                     // TODO: I don't know how to easily store the SingleOwnerAccount
                     // and it's generic types without complexifiying the whole typing.
                     // So it's constructed at every call. There is surely a better approach.
-                    let (account_address, signer) = match (self.account_address, &self.signer) {
-                        (Some(a), Some(s)) => (a, s),
+                    let account = match &self.account {
+                        Some(a) => a,
                         // TODO: better error handling here.
-                        _ => return Err(anyhow::anyhow!("Account address and signer are required to send invoke transactions"))
+                        _ => return Err(anyhow::anyhow!("Account is required to send invoke transactions"))
                     };
-
-                    let account = starknet::accounts::SingleOwnerAccount::new(
-                        &self.provider,
-                        signer,
-                        account_address,
-                        self.chain_id
-                    );
 
                     let mut calldata = vec![];
                     #(#serializations)*

--- a/crates/abigen-macro/src/expand/function.rs
+++ b/crates/abigen-macro/src/expand/function.rs
@@ -49,7 +49,7 @@ impl Expandable for CairoFunction {
         let mut serializations: Vec<TokenStream2> = vec![];
         for (name, abi_type) in &self.inputs {
             let name = str_to_ident(&name);
-            let ty = str_to_type(&abi_type.to_rust_item_path());
+            let ty = str_to_type(&abi_type.to_rust_type_path());
             serializations.push(quote! {
                 calldata.extend(#ty::serialize(&#name));
             });
@@ -57,12 +57,12 @@ impl Expandable for CairoFunction {
 
         let out_res = match &self.output {
             Some(o) => {
-                let out_item_path = str_to_type(&o.to_rust_item_path());
+                let out_type_path = str_to_type(&o.to_rust_type_path());
                 match o {
                     // Tuples type used as rust type path must be surrounded
                     // by LT/GT.
-                    AbiType::Tuple(_) => quote!(<#out_item_path>::deserialize(r, 0)),
-                    _ => quote!(#out_item_path::deserialize(&r, 0)),
+                    AbiType::Tuple(_) => quote!(<#out_type_path>::deserialize(r, 0)),
+                    _ => quote!(#out_type_path::deserialize(&r, 0)),
                 }
             }
             None => quote!(),

--- a/crates/abigen-macro/src/expand/struct.rs
+++ b/crates/abigen-macro/src/expand/struct.rs
@@ -40,7 +40,7 @@ impl Expandable for CairoStruct {
             let name = str_to_ident(&name);
             names.push(quote!(#name));
 
-            let ty = str_to_type(&member.to_rust_item_path());
+            let ty = str_to_type(&member.to_rust_type_path());
 
             // Tuples type used as rust type path must be surrounded
             // by LT/GT.

--- a/crates/abigen-macro/src/lib.rs
+++ b/crates/abigen-macro/src/lib.rs
@@ -72,7 +72,7 @@ pub fn abigen(input: TokenStream) -> TokenStream {
 
     // TODO: fix imports. Do we want to import everything at the top
     // of the contract, and put the contract inside a module?
-
+    // TODO: Make generic. P: Provider, A: Account.
     tokens.push(quote! {
         #[derive(Debug)]
         pub struct #contract_name<'a>
@@ -83,7 +83,6 @@ pub fn abigen(input: TokenStream) -> TokenStream {
         }
 
         // TODO: Perhaps better than anyhow, a custom error?
-        // TODO: Make provider reference
         impl<'a> #contract_name<'a> {
             pub fn new(
                 address: starknet::core::types::FieldElement,
@@ -96,7 +95,7 @@ pub fn abigen(input: TokenStream) -> TokenStream {
                 }
             }
 
-            pub fn with_account(mut self, account: &'a SingleOwnerAccount<&'a starknet::providers::AnyProvider, starknet::signers::LocalWallet>,
+            pub fn with_account(mut self, account: &'a starknet::accounts::SingleOwnerAccount<&'a starknet::providers::AnyProvider, starknet::signers::LocalWallet>,
             ) -> Self {
                 self.account = Some(account);
                 self

--- a/crates/cairo-types/src/types/mod.rs
+++ b/crates/cairo-types/src/types/mod.rs
@@ -2,5 +2,5 @@ mod array;
 mod data_type;
 mod integers;
 mod option;
-mod tuple;
 pub mod starknet;
+mod tuple;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use abigen_macro::abigen;
 use anyhow::Result;
 use cairo_types::ty::CairoType;
 
-use starknet::accounts::Account;
+use starknet::accounts::{Account, SingleOwnerAccount};
 
 use starknet::core::types::*;
 use starknet::providers::{jsonrpc::HttpTransport, AnyProvider, JsonRpcClient, Provider};
@@ -50,23 +50,20 @@ async fn main() -> Result<()> {
     ))
     .unwrap();
 
-    let signer2 = wallet_from_private_key(&Some(
-        "0x0000001800000000300000180000000000030000000000003006001800006600".to_string(),
-    ))
-    .unwrap();
-
     // If you modify the contract, even with a salt, it will be deployed at
     // a different address.
     let contract_address = FieldElement::from_hex_be(
         "0x0546a164c8d10fd38652b6426ef7be159965deb9a0cbf3e8a899f8a42fd86761",
     )
     .unwrap();
+    let chain_id = provider.chain_id().await?;
+    let account = SingleOwnerAccount::new(&provider, signer, account_address, chain_id);
     let contract_a = ContractA::new(contract_address, &provider)
-        .with_account(account_address, signer)
+        .with_account(&account)
         .await?;
 
     let contract_b = ContractB::new(contract_address, &provider)
-        .with_account(account_address, signer2)
+        .with_account(&account)
         .await?;
 
     contract_a

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use abigen_macro::abigen;
 use anyhow::Result;
 use cairo_types::ty::CairoType;
 
-use starknet::accounts::{Account, SingleOwnerAccount};
+use starknet::accounts::SingleOwnerAccount;
 
 use starknet::core::types::*;
 use starknet::providers::{jsonrpc::HttpTransport, AnyProvider, JsonRpcClient, Provider};
@@ -62,9 +62,15 @@ async fn main() -> Result<()> {
         .with_account(&account)
         .await?;
 
-    let contract_b = ContractB::new(contract_address, &provider)
-        .with_account(&account)
-        .await?;
+    // 1) you can either call using explicit type ( without `with_account` )
+    // TODO: Is there any way that don't need explicit type and still keep A generic even without account?
+    let contract_b: ContractB<&AnyProvider, SingleOwnerAccount<AnyProvider, LocalWallet>> =
+        ContractB::new(contract_address, &provider);
+
+    // 2) Or define with account.
+    // let contract_b = ContractB::new(contract_address, &provider)
+    //     .with_account(&account)
+    //     .await?;
 
     contract_a
         .set_val(FieldElement::TWO)

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ use cairo_types::ty::CairoType;
 use starknet::accounts::{Account, SingleOwnerAccount};
 
 use starknet::core::types::*;
+use starknet::macros::felt;
 use starknet::providers::{jsonrpc::HttpTransport, AnyProvider, JsonRpcClient, Provider};
 use starknet::signers::{LocalWallet, SigningKey};
-use starknet::macros::felt;
 
 use url::Url;
 
@@ -40,9 +40,9 @@ async fn main() -> Result<()> {
     let provider =
         AnyProvider::JsonRpcHttp(JsonRpcClient::new(HttpTransport::new(rpc_url.clone())));
 
-    let account_address = felt!("0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973");
+    let account_address =
+        felt!("0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973");
 
-    // Let user to define their own signer, it will be generic S. LocalWallet etc.
     let signer = wallet_from_private_key(&Some(
         "0x0000001800000000300000180000000000030000000000003006001800006600".to_string(),
     ))
@@ -50,7 +50,8 @@ async fn main() -> Result<()> {
 
     // If you modify the contract, even with a salt, it will be deployed at
     // a different address.
-    let contract_address = felt!("0x0546a164c8d10fd38652b6426ef7be159965deb9a0cbf3e8a899f8a42fd86761");
+    let contract_address =
+        felt!("0x0546a164c8d10fd38652b6426ef7be159965deb9a0cbf3e8a899f8a42fd86761");
 
     let chain_id = provider.chain_id().await?;
     let account = SingleOwnerAccount::new(&provider, signer, account_address, chain_id);

--- a/src/tests/starknet_types.rs
+++ b/src/tests/starknet_types.rs
@@ -1,6 +1,6 @@
 use abigen_macro::abigen;
+use cairo_types::types::starknet::{ClassHash, ContractAddress, EthAddress};
 use cairo_types::CairoType;
-use cairo_types::types::starknet::{ContractAddress, ClassHash, EthAddress};
 use starknet::core::types::FieldElement;
 
 #[test]
@@ -41,7 +41,9 @@ fn test_starknet_eth_address() {
 
 #[test]
 fn test_starknet_types() {
-    abigen!(ContractA, r#"
+    abigen!(
+        ContractA,
+        r#"
 [
   {
     "type": "struct",
@@ -62,7 +64,8 @@ fn test_starknet_types() {
     ]
   }
 ]
-"#);
+"#
+    );
 
     let snt = SnTypes {
         addr: ContractAddress(FieldElement::ONE),


### PR DESCRIPTION
#14 

- signer / provider is all reference ( can reuse )
- use generic input ( P : Provider, A: Account )
- update abigen macro using builders pattern `with_account`

TODO
- if not use with_account, contract which accept generic P : Provider, A: Account, will return error bcs they don't know A's specific type. Current temporary solution is explicitly define P & A if not using `with_account`. Can open other issue 