### PR TITLE
implement event

### DIFF
--- a/crates/abigen-macro/src/expand/event.rs
+++ b/crates/abigen-macro/src/expand/event.rs
@@ -1,0 +1,15 @@
+use crate::Expandable;
+use cairo_type_parser::CairoEvent;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+// TODO: implement CairoEvent
+impl Expandable for CairoEvent {
+    fn expand_decl(&self) -> TokenStream2 {
+        quote!()
+    }
+
+    fn expand_impl(&self) -> TokenStream2 {
+        quote!()
+    }
+}

--- a/crates/abigen-macro/src/expand/mod.rs
+++ b/crates/abigen-macro/src/expand/mod.rs
@@ -3,6 +3,7 @@
 // on the quote!, but we should care about trailing commas for instance.
 
 mod r#enum;
+mod r#event;
 mod r#function;
 mod r#struct;
 mod utils;

--- a/crates/cairo-type-parser/src/lib.rs
+++ b/crates/cairo-type-parser/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod abi_type;
 
-use starknet::core::types::contract::StateMutability;
+use starknet::core::types::contract::{EventFieldKind, StateMutability};
 
 use abi_type::AbiType;
 
@@ -10,6 +10,7 @@ pub enum CairoAbiEntry {
     Struct(CairoStruct),
     Enum(CairoEnum),
     Function(CairoFunction),
+    Event(CairoEvent),
 }
 
 #[derive(Debug)]
@@ -32,4 +33,37 @@ pub struct CairoFunction {
     pub inputs: Vec<(String, AbiType)>,
     // For now, only one output type is supported (or none).
     pub output: Option<AbiType>,
+}
+
+// Event
+#[derive(Debug)]
+pub enum CairoEvent {
+    /// Cairo 2.x ABI event entry
+    Typed(CairoTypedAbiEvent),
+    /// Cairo 1.x ABI event entry
+    Untyped(CairoUntypedAbiEvent),
+}
+
+#[derive(Debug)]
+pub struct CairoUntypedAbiEvent {
+    pub name: AbiType,
+    pub inputs: Vec<(String, AbiType)>,
+}
+
+#[derive(Debug)]
+pub enum CairoTypedAbiEvent {
+    Struct(CairoAbiEventStruct),
+    Enum(CairoAbiEventEnum),
+}
+
+#[derive(Debug)]
+pub struct CairoAbiEventStruct {
+    pub name: AbiType,
+    pub members: Vec<(String, AbiType, EventFieldKind)>,
+}
+
+#[derive(Debug)]
+pub struct CairoAbiEventEnum {
+    pub name: AbiType,
+    pub variants: Vec<(String, AbiType, EventFieldKind)>,
 }


### PR DESCRIPTION
### Consideration
Event, I might also use `struct` and `enum` expansion. If then, we cannot distinguish between `struct` & `eventStruct` and `enum` & `eventEnum`. The difference between those two is, event type have one more parameter which is `kind`. 

```json
      {
        "name": "user",
        "type": "core::starknet::contract_address::ContractAddress",
        "kind": "key"
      },
```

Right now not sure how we can use event if we could expand in macro. We can get event data from transaction recept, and the type of this is felt, so might be useful to have (de)serialization method for event. 

So not sure `kind` is important or not. => Decided to implement independent expansion in `event.rs`, which will handle `kind` also. 

Then later if we could find out that field is not using, can refactor using current expansion of `struct` and `enum`. 